### PR TITLE
Add table and media artifacts

### DIFF
--- a/ClientApp/src/artifactRegistry.ts
+++ b/ClientApp/src/artifactRegistry.ts
@@ -1,6 +1,12 @@
 import ProductCard from './components/ProductCard.vue';
+import FileDownload from './components/FileDownload.vue';
+import TableComponent from './components/TableComponent.vue';
+import MediaGallery from './components/MediaGallery.vue';
 
 export const artifactRegistry: Record<string, any> = {
   prod_cards: ProductCard,
+  file_list: FileDownload,
+  table_data: TableComponent,
+  media_gallery: MediaGallery,
   // Add more artifact types here
 };

--- a/ClientApp/src/components/FileDownload.vue
+++ b/ClientApp/src/components/FileDownload.vue
@@ -1,0 +1,55 @@
+<template>
+  <div class="file-download-list">
+    <a
+      v-for="file in data"
+      :key="file.name"
+      class="file-item"
+      :href="file.url"
+      download
+    >
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+      >
+        <path
+          d="M12 2a1 1 0 011 1v12.59l3.3-3.3a1 1 0 011.4 1.42l-5 5a1 1 0 01-1.4 0l-5-5a1 1 0 011.4-1.42l3.3 3.3V3a1 1 0 011-1z"
+        />
+        <path
+          d="M5 20a1 1 0 011-1h12a1 1 0 011 1 1 1 0 01-1 1H6a1 1 0 01-1-1z"
+        />
+      </svg>
+      {{ file.name }}
+    </a>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ data: Array<{ name: string; url: string }> }>();
+</script>
+
+<style scoped>
+.file-download-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.file-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--app-card-bg);
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+  color: var(--app-text);
+  text-decoration: none;
+  transition: background 0.2s ease;
+}
+
+.file-item:hover {
+  background: var(--app-hover);
+}
+</style>

--- a/ClientApp/src/components/MediaGallery.vue
+++ b/ClientApp/src/components/MediaGallery.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="media-gallery">
+    <div v-for="(item, i) in data" :key="i" class="media-item">
+      <img v-if="item.type === 'image'" :src="item.url" :alt="item.alt || 'image'" />
+      <video v-else-if="item.type === 'video'" controls :src="item.url"></video>
+      <audio v-else-if="item.type === 'audio'" controls :src="item.url"></audio>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ data: Array<{ type: string; url: string; alt?: string }> }>();
+</script>
+
+<style scoped>
+.media-gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.media-item img,
+.media-item video,
+.media-item audio {
+  max-width: 240px;
+  border-radius: 8px;
+}
+</style>

--- a/ClientApp/src/components/TableComponent.vue
+++ b/ClientApp/src/components/TableComponent.vue
@@ -1,0 +1,35 @@
+<template>
+  <table class="table-component" v-if="rows.length">
+    <thead>
+      <tr>
+        <th v-for="h in headers" :key="h">{{ h }}</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="(row,i) in rows" :key="i">
+        <td v-for="h in headers" :key="h">{{ row[h] }}</td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ data: Array<Record<string, any>> }>();
+const rows = props.data || [];
+const headers = rows.length ? Object.keys(rows[0]) : [];
+</script>
+
+<style scoped>
+.table-component {
+  width: 100%;
+  border-collapse: collapse;
+}
+.table-component th,
+.table-component td {
+  padding: 8px 12px;
+  border: 1px solid var(--app-border);
+}
+.table-component th {
+  background: var(--app-hover);
+}
+</style>

--- a/ClientApp/src/composables/useStreamHub.ts
+++ b/ClientApp/src/composables/useStreamHub.ts
@@ -6,6 +6,8 @@ export const artifactData = reactive<Record<string, any>>({});
 
 export function useStreamHub() {
   function sendMessage(text: string) {
+    // Replace artifacts from any prior request
+    for (const k in artifactData) delete artifactData[k];
     // Add user message as a new bubble
     chatSegments.value.push(text);
     // Add an empty assistant bubble for the response

--- a/ClientApp/src/mock/mockStreamApi.ts
+++ b/ClientApp/src/mock/mockStreamApi.ts
@@ -1,5 +1,19 @@
 import productData from './mockdata.json';
 
+const sampleFiles = [
+  { name: 'catalog.pdf', url: 'https://example.com/catalog.pdf' },
+  { name: 'spec-sheet.pdf', url: 'https://example.com/spec-sheet.pdf' }
+];
+
+const sampleTable = [
+  { Name: 'Alice', Age: 30 },
+  { Name: 'Bob', Age: 25 }
+];
+
+const sampleMedia = [
+  { type: 'video', url: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm' }
+];
+
 export interface StreamFrame {
   channel: 'chat' | 'artifact';
   delta?: string;
@@ -19,15 +33,58 @@ const getRandomProducts = (n: number) => {
 };
 
 export function sendUserMessage(userText: string, onFrame: (f: StreamFrame) => void) {
-  const scenario: Array<{ delayMs: number; frame: StreamFrame }> = [
-    { delayMs: 0,   frame: { channel: 'chat', delta: 'Here ' } },
-    { delayMs: 180, frame: { channel: 'chat', delta: 'are ' } },
-    { delayMs: 120, frame: { channel: 'chat', delta: 'some ' } },
-    { delayMs: 180, frame: { channel: 'chat', delta: 'camera ' } },
-    { delayMs: 100, frame: { channel: 'artifact', artifactId: 'prod_cards', op: 'replace', value: getRandomProducts(6) } },
-    { delayMs: 140, frame: { channel: 'chat', delta: 'recommendations.' } },
-    { delayMs: 60,  frame: { channel: 'chat', delta: '', isFinal: true } },
-  ];
+  const scenario: Array<{ delayMs: number; frame: StreamFrame }> = [];
+
+  // All scenarios begin with "Here" for demo consistency
+  scenario.push({ delayMs: 0, frame: { channel: 'chat', delta: 'Here ' } });
+
+  const lower = userText.toLowerCase();
+
+  if (lower.includes('file')) {
+    scenario.push(
+      { delayMs: 160, frame: { channel: 'chat', delta: 'are ' } },
+      { delayMs: 120, frame: { channel: 'chat', delta: 'the ' } },
+      { delayMs: 140, frame: { channel: 'chat', delta: 'files ' } },
+      { delayMs: 120, frame: { channel: 'chat', delta: 'you ' } },
+      { delayMs: 100, frame: { channel: 'chat', delta: 'requested.' } },
+      { delayMs: 60,  frame: { channel: 'chat', delta: '', isFinal: true } },
+      { delayMs: 120, frame: { channel: 'artifact', artifactId: 'file_list', op: 'replace', value: sampleFiles } }
+    );
+  } else if (lower.includes('product')) {
+    scenario.push(
+      { delayMs: 180, frame: { channel: 'chat', delta: 'are ' } },
+      { delayMs: 120, frame: { channel: 'chat', delta: 'some ' } },
+      { delayMs: 180, frame: { channel: 'chat', delta: 'camera ' } },
+      { delayMs: 100, frame: { channel: 'artifact', artifactId: 'prod_cards', op: 'replace', value: getRandomProducts(6) } },
+      { delayMs: 140, frame: { channel: 'chat', delta: 'recommendations.' } },
+      { delayMs: 60,  frame: { channel: 'chat', delta: '', isFinal: true } }
+    );
+  } else if (lower.includes('table')) {
+    scenario.push(
+      { delayMs: 160, frame: { channel: 'chat', delta: 'is ' } },
+      { delayMs: 120, frame: { channel: 'chat', delta: 'your ' } },
+      { delayMs: 140, frame: { channel: 'chat', delta: 'requested ' } },
+      { delayMs: 120, frame: { channel: 'chat', delta: 'table.' } },
+      { delayMs: 60,  frame: { channel: 'chat', delta: '', isFinal: true } },
+      { delayMs: 120, frame: { channel: 'artifact', artifactId: 'table_data', op: 'replace', value: sampleTable } }
+    );
+  } else if (lower.includes('video')) {
+    scenario.push(
+      { delayMs: 160, frame: { channel: 'chat', delta: 'is ' } },
+      { delayMs: 120, frame: { channel: 'chat', delta: 'your ' } },
+      { delayMs: 140, frame: { channel: 'chat', delta: 'video.' } },
+      { delayMs: 60,  frame: { channel: 'chat', delta: '', isFinal: true } },
+      { delayMs: 120, frame: { channel: 'artifact', artifactId: 'media_gallery', op: 'replace', value: sampleMedia } }
+    );
+  } else {
+    scenario.push(
+      { delayMs: 180, frame: { channel: 'chat', delta: 'is ' } },
+      { delayMs: 120, frame: { channel: 'chat', delta: 'a ' } },
+      { delayMs: 180, frame: { channel: 'chat', delta: 'demo ' } },
+      { delayMs: 100, frame: { channel: 'chat', delta: 'response.' } },
+      { delayMs: 60,  frame: { channel: 'chat', delta: '', isFinal: true } }
+    );
+  }
   let t = 0;
   scenario.forEach(({ delayMs, frame }) => {
     t += delayMs;

--- a/ClientApp/tests/FileDownload.test.ts
+++ b/ClientApp/tests/FileDownload.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import FileDownload from '../src/components/FileDownload.vue';
+
+describe('FileDownload', () => {
+  it('renders file links with download attribute', () => {
+    const wrapper = mount(FileDownload, {
+      props: {
+        data: [{ name: 'a.pdf', url: 'https://example.com/a.pdf' }]
+      }
+    });
+    const link = wrapper.find('a');
+    expect(link.attributes('download')).toBeDefined();
+    expect(link.text()).toContain('a.pdf');
+  });
+});

--- a/ClientApp/tests/MediaGallery.test.ts
+++ b/ClientApp/tests/MediaGallery.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import MediaGallery from '../src/components/MediaGallery.vue';
+
+describe('MediaGallery', () => {
+  it('renders video element when type is video', () => {
+    const wrapper = mount(MediaGallery, {
+      props: { data: [{ type: 'video', url: 'video.mp4' }] }
+    });
+    expect(wrapper.find('video').exists()).toBe(true);
+  });
+});

--- a/ClientApp/tests/TableComponent.test.ts
+++ b/ClientApp/tests/TableComponent.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import TableComponent from '../src/components/TableComponent.vue';
+
+describe('TableComponent', () => {
+  it('renders table headers and cells', () => {
+    const wrapper = mount(TableComponent, {
+      props: { data: [{ Name: 'Alice', Age: 30 }] }
+    });
+    expect(wrapper.findAll('th').length).toBe(2);
+    expect(wrapper.find('tbody td').text()).toBe('Alice');
+  });
+});

--- a/ClientApp/tests/artifactRegistry.test.ts
+++ b/ClientApp/tests/artifactRegistry.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect } from 'vitest';
 import { artifactRegistry } from '../src/artifactRegistry';
 import ProductCard from '../src/components/ProductCard.vue';
+import FileDownload from '../src/components/FileDownload.vue';
+import TableComponent from '../src/components/TableComponent.vue';
+import MediaGallery from '../src/components/MediaGallery.vue';
 
 describe('artifactRegistry', () => {
   it('maps prod_cards to ProductCard', () => {
     expect(artifactRegistry['prod_cards']).toBe(ProductCard);
+  });
+
+  it('maps file_list to FileDownload', () => {
+    expect(artifactRegistry['file_list']).toBe(FileDownload);
+  });
+
+  it('maps table_data to TableComponent', () => {
+    expect(artifactRegistry['table_data']).toBe(TableComponent);
+  });
+
+  it('maps media_gallery to MediaGallery', () => {
+    expect(artifactRegistry['media_gallery']).toBe(MediaGallery);
   });
 });

--- a/ClientApp/tests/mockStreamApi.test.ts
+++ b/ClientApp/tests/mockStreamApi.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { sendUserMessage } from '../src/mock/mockStreamApi';
+
+vi.useFakeTimers();
+
+describe('mockStreamApi keyword scenarios', () => {
+  it('returns product artifacts when question mentions product', () => {
+    const frames: any[] = [];
+    sendUserMessage('show me product details', f => frames.push(f));
+    vi.runAllTimers();
+    expect(frames.some(f => f.artifactId === 'prod_cards')).toBe(true);
+    expect(frames.some(f => f.artifactId === 'file_list')).toBe(false);
+  });
+
+  it('returns file artifacts when question mentions file', () => {
+    const frames: any[] = [];
+    sendUserMessage('please send the file', f => frames.push(f));
+    vi.runAllTimers();
+    expect(frames.some(f => f.artifactId === 'file_list')).toBe(true);
+    expect(frames.some(f => f.artifactId === 'prod_cards')).toBe(false);
+  });
+
+  it('returns table artifacts when question mentions table', () => {
+    const frames: any[] = [];
+    sendUserMessage('show table result', f => frames.push(f));
+    vi.runAllTimers();
+    expect(frames.some(f => f.artifactId === 'table_data')).toBe(true);
+  });
+
+  it('returns media artifacts when question mentions video', () => {
+    const frames: any[] = [];
+    sendUserMessage('I want a video', f => frames.push(f));
+    vi.runAllTimers();
+    expect(frames.some(f => f.artifactId === 'media_gallery')).toBe(true);
+  });
+});

--- a/ClientApp/tests/useStreamHub.extra.test.ts
+++ b/ClientApp/tests/useStreamHub.extra.test.ts
@@ -50,4 +50,17 @@ describe('useStreamHub extra operations', () => {
     expect(chatSegments.value).toEqual([]);
     expect(Object.keys(artifactData).length).toBe(0);
   });
+
+  it('clears previous artifacts when sending a new message', () => {
+    frames.push({ channel: 'artifact', artifactId: 'old', op: 'replace', value: [1] });
+    const hub = useStreamHub();
+    hub.sendMessage('first');
+    expect(artifactData['old']).toEqual([1]);
+
+    frames.length = 0;
+    frames.push({ channel: 'artifact', artifactId: 'new', op: 'replace', value: [2] });
+    hub.sendMessage('second');
+    expect(artifactData.hasOwnProperty('old')).toBe(false);
+    expect(artifactData['new']).toEqual([2]);
+  });
 });

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ This project is a **frontend-only** demonstration of a dual-panel, real-time AI 
 
 - **Frontend-only:** No backend required; all data and streaming are simulated with mock APIs.
 - **Dual-panel UI:** Live chat (streaming token-by-token) and artifacts (cards, tables, etc.), styled with Bootstrap 5.
-- **Dynamic artifacts:** Registry pattern allows easy addition of new artifact types (e.g., product cards, charts).
+- **Dynamic artifacts:** Registry pattern allows easy addition of new artifact types (e.g., product cards, file downloads, tables, media galleries).
 - **Theme switch:** Toggle light/dark mode using Bootstrap 5 utility classes.
 - **Randomized responses:** Each chat request streams a random scenario from local mock data for realism.
 - **Maintainable codebase:** Modern Vue 3 + Vite + TypeScript structure, composables, and clear separation of concerns.
+- **Keyword demos:** Include `product`, `file`, `table`, or `video` in your question to stream example product cards, downloadable files, tables, or media content.
+- **Fresh artifacts:** Each new question replaces previously streamed artifacts for clarity.
 
 ---
 
@@ -24,7 +26,10 @@ ClientApp/
 │   │   ├── ChatPanel.vue        # Chat panel (left)
 │   │   ├── ArtifactsPane.vue    # Artifacts panel (right)
 │   │   ├── ThemeToggle.vue      # Theme switch button
-│   │   └── ProductCard.vue      # Example artifact component
+│   │   ├── ProductCard.vue      # Example product card component
+│   │   ├── FileDownload.vue     # File download artifact component
+│   │   ├── TableComponent.vue   # Table artifact component
+│   │   └── MediaGallery.vue     # Media gallery artifact component
 │   ├── artifactRegistry.ts      # artifactId/type → Vue component registry
 │   ├── composables/
 │   │   └── useStreamHub.ts      # Streaming logic (mock API integration)


### PR DESCRIPTION
## Summary
- implement `TableComponent` and `MediaGallery` components
- register new artifacts in the registry
- extend the mock API to stream table or media frames for questions with `table` or `video`
- update documentation with keyword instructions and architecture
- add unit tests for new components and API keywords

## Testing
- `npm install`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6857e4221d708332af1347e62e8c7faf